### PR TITLE
Fix compatibility issue with Openfire 4.9.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,8 @@ Spam Blacklist Plugin Changelog
 
 <p><b>1.0.2</b> -- To be Determined</p>
 <ul>
+    <li>This plugin now requires Openfire 4.8.0 or later.</li>
+    <li><a href="https://github.com/igniterealtime/openfire-blacklistSpam-plugin/issues/7">Issue #7</a>: Compatibility with Openfire 4.9.0</li>
 </ul>
 
 <p><b>1.0.1</b> -- November 21, 2023</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,6 +6,6 @@
     <description>Uses an external blacklist to reject traffic from specific addresses.</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2023-11-21</date>
-    <minServerVersion>4.0.0</minServerVersion>
+    <date>2024-09-11</date>
+    <minServerVersion>4.8.0</minServerVersion>
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0</version>
+        <version>4.8.0</version>
     </parent>
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>

--- a/src/main/java/org/igniterealtime/openfire/plugin/blacklistspam/StanzaBlocker.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/blacklistspam/StanzaBlocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ignite Realtime Foundation
+ * Copyright 2019-2024 Ignite Realtime Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import org.xmpp.packet.Packet;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -96,7 +95,7 @@ public class StanzaBlocker implements PacketInterceptor, PropertyEventListener
      */
     public void store( final Packet stanza )
     {
-        final Path logDir = Paths.get(JiveGlobals.getHomeDirectory(), "blacklist", "blocked" );
+        final Path logDir = JiveGlobals.getHomePath().resolve("blacklist").resolve("blocked");
         final Instant now = Instant.now();
         final String fileName = DateTimeFormatter.BASIC_ISO_DATE.withZone(ZoneId.systemDefault()).format(now).concat(".txt" );
         final String data = DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.systemDefault()).format(now) + " from [" + stanza.getFrom() + "]: " + stanza.toXML() + System.lineSeparator();


### PR DESCRIPTION
Replaced Openfire API usage that was deprecated in Openfire 4.8.0 and removed in 4.9.0.

This plugin is now compatible with Openfire 4.9.0 and requires 4.8.0 or later. No longer compatible with versions older than 4.8.0.

fixes #7